### PR TITLE
Restaurant dashboard UI: live order queue, management panels, logout redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,14 +651,13 @@ This architecture satisfies the requirement that "all three components can be de
 - [ ] Email credentials upon approval
 - [x] Mock credential notification for frontend demo
 
-#### Restaurant Portal
-- [ ] Login page with username/password
+- [x] Login page with username/password (restaurant + staff tabs)
 - [ ] Logout functionality
-- [ ] Change password feature
-  - [ ] Minimum 6 characters validation
-  - [ ] At least 1 uppercase letter
-  - [ ] At least 1 lowercase letter
-  - [ ] At least 1 number
+- [x] Change password feature (mocked client-side)
+  - [x] Minimum 6 characters validation
+  - [x] At least 1 uppercase letter
+  - [x] At least 1 lowercase letter
+  - [x] At least 1 number
 - [ ] Dashboard with restaurant info display
 - [ ] Edit menu functionality
   - [ ] Add new items

--- a/app/restaurant/dashboard/components/app-sidebar.tsx
+++ b/app/restaurant/dashboard/components/app-sidebar.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import {
+  IconAlertTriangle,
+  IconClock,
+  IconDashboard,
+  IconHelp,
+  IconInnerShadowTop,
+  IconSearch,
+  IconShoppingCart,
+  IconToolsKitchen2,
+  IconUsers,
+} from '@tabler/icons-react'
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar'
+import { NavMain } from './nav-main'
+import { NavSecondary } from './nav-secondary'
+import { NavUser } from './nav-user'
+
+const data = {
+  user: {
+    name: 'Citrus & Thyme',
+    email: 'hello@citrusandthyme.com',
+    avatar: '/avatars/restaurant-citrus-thyme.png',
+  },
+  navMain: [
+    {
+      title: 'Overview',
+      url: '/restaurant/dashboard',
+      icon: IconDashboard,
+      badge: 'Live',
+    },
+    {
+      title: 'Order queue',
+      url: '/restaurant/dashboard/order-queue',
+      icon: IconShoppingCart,
+      badge: 'Live',
+    },
+    {
+      title: 'Menu management',
+      url: '/restaurant/dashboard#menu-management',
+      icon: IconToolsKitchen2,
+    },
+    {
+      title: 'Operating hours',
+      url: '/restaurant/dashboard#operating-hours',
+      icon: IconClock,
+    },
+    {
+      title: 'Contact details',
+      url: '/restaurant/dashboard#contact-info',
+      icon: IconUsers,
+    },
+    {
+      title: 'Withdraw from FrontDash',
+      url: '/restaurant/dashboard#withdrawal',
+      icon: IconAlertTriangle,
+    },
+  ],
+  navSecondary: [
+    {
+      title: 'Support center',
+      url: '/restaurant/support',
+      icon: IconHelp,
+    },
+    {
+      title: 'Search knowledge base',
+      url: '/restaurant/search',
+      icon: IconSearch,
+    },
+  ],
+}
+
+export function RestaurantSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar collapsible="offcanvas" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
+              <Link href="/restaurant/dashboard">
+                <IconInnerShadowTop className="!size-5 text-emerald-500" />
+                <span className="text-base font-semibold">FrontDash • Restaurant</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={data.navMain} />
+        <NavSecondary items={data.navSecondary} className="mt-auto" />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser user={data.user} />
+      </SidebarFooter>
+    </Sidebar>
+  )
+}

--- a/app/restaurant/dashboard/components/contact-details-card.tsx
+++ b/app/restaurant/dashboard/components/contact-details-card.tsx
@@ -1,0 +1,293 @@
+'use client'
+
+import { useState } from 'react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { IconCheck, IconPlus, IconStar } from '@tabler/icons-react'
+import { useFieldArray, useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+
+import { restaurantContact, type RestaurantContactDetails } from '../mock-data'
+
+const contactSchema = z.object({
+  contactPerson: z.string().min(2, 'Enter the primary contact name'),
+  email: z.string().email('Enter a valid email address'),
+  phoneNumbers: z
+    .array(z.string().regex(/^\d{10}$/, 'Phone numbers must be 10 digits'))
+    .min(1, 'Provide at least one phone number'),
+  street: z.string().min(5, 'Enter the pickup street address'),
+  suite: z.string().trim().max(32, 'Suite exceeds 32 characters').optional(),
+  city: z.string().min(2, 'Enter the city'),
+  state: z.string().length(2, 'Use 2-letter state code'),
+  postalCode: z.string().min(3, 'Enter the postal code'),
+  notes: z.string().trim().max(180, 'Keep notes under 180 characters').optional(),
+})
+
+const defaultValues = {
+  contactPerson: restaurantContact.contactPerson,
+  email: restaurantContact.email,
+  phoneNumbers: restaurantContact.phoneNumbers,
+  street: restaurantContact.street,
+  suite: restaurantContact.suite ?? '',
+  city: restaurantContact.city,
+  state: restaurantContact.state,
+  postalCode: restaurantContact.postalCode,
+  notes: '',
+}
+
+type ContactFormValues = z.infer<typeof contactSchema>
+
+export function ContactDetailsCard() {
+  const [lastSaved, setLastSaved] = useState<Date | null>(null)
+
+  const form = useForm<ContactFormValues>({
+    resolver: zodResolver(contactSchema),
+    defaultValues,
+  })
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'phoneNumbers',
+  })
+
+  function onSubmit(values: ContactFormValues) {
+    const payload: RestaurantContactDetails = {
+      contactPerson: values.contactPerson,
+      email: values.email,
+      phoneNumbers: values.phoneNumbers,
+      street: values.street,
+      suite: values.suite || undefined,
+      city: values.city,
+      state: values.state,
+      postalCode: values.postalCode,
+    }
+
+    console.info('Contact details queued for update:', payload)
+    setLastSaved(new Date())
+    form.reset({ ...values, notes: '' })
+  }
+
+  return (
+    <section id="contact-info" className="scroll-mt-28">
+      <Card className="border-emerald-100 bg-white/90 shadow-lg shadow-emerald-100/40">
+        <CardHeader className="space-y-3">
+          <CardTitle className="text-2xl font-semibold text-neutral-900">
+            Contact details
+          </CardTitle>
+          <p className="text-sm text-neutral-600">
+            Keep dispatch lines current so the FrontDash support pod can reach the shift
+            lead anytime an order question pops up.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+            <Badge
+              variant="outline"
+              className="border-emerald-200 bg-emerald-50 text-emerald-700"
+            >
+              <IconStar className="size-4" /> Primary: {restaurantContact.contactPerson}
+            </Badge>
+            {lastSaved ? (
+              <span className="text-neutral-500">
+                <IconCheck className="mr-1 inline size-4 text-emerald-600" /> Updated{' '}
+                {lastSaved.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+              </span>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              className="grid gap-6 lg:grid-cols-[1.1fr_1fr]"
+              onSubmit={form.handleSubmit(onSubmit)}
+            >
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="contactPerson"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Primary contact</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Morgan Ellis" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email address</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="ops@citrusandthyme.com"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="space-y-3">
+                  <FormLabel>Phone numbers</FormLabel>
+                  <FormDescription>
+                    Enter 10-digit numbers (FrontDash adds formatting).
+                  </FormDescription>
+                  <div className="space-y-3">
+                    {fields.map((field, index) => (
+                      <FormField
+                        key={field.id}
+                        control={form.control}
+                        name={`phoneNumbers.${index}`}
+                        render={({ field: phoneField }) => (
+                          <FormItem>
+                            <div className="flex items-center gap-3">
+                              <FormControl>
+                                <Input
+                                  inputMode="numeric"
+                                  placeholder="5125550198"
+                                  {...phoneField}
+                                />
+                              </FormControl>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                className="size-8"
+                                onClick={() => remove(index)}
+                                disabled={fields.length <= 1}
+                              >
+                                <span className="sr-only">Remove phone</span>×
+                              </Button>
+                            </div>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ))}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-2"
+                    onClick={() => append('')}
+                  >
+                    <IconPlus className="size-4" /> Add phone number
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-4 rounded-2xl border border-emerald-100 bg-emerald-50/40 p-5">
+                <FormField
+                  control={form.control}
+                  name="street"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Street address</FormLabel>
+                      <FormControl>
+                        <Input placeholder="410 Market Street" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="suite"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Suite or unit (optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Suite B" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid grid-cols-3 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="city"
+                    render={({ field }) => (
+                      <FormItem className="col-span-2">
+                        <FormLabel>City</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Austin" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="state"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>State</FormLabel>
+                        <FormControl>
+                          <Input placeholder="TX" maxLength={2} {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="postalCode"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Postal code</FormLabel>
+                      <FormControl>
+                        <Input placeholder="78704" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="notes"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Internal notes (optional)</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={3}
+                          placeholder="Escalate to Morgan between 8a-11a."
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex items-center justify-end gap-3">
+                  <Button type="submit">Save contact details</Button>
+                </div>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/restaurant/dashboard/components/menu-management-panel.tsx
+++ b/app/restaurant/dashboard/components/menu-management-panel.tsx
@@ -1,0 +1,438 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { IconPlus, IconTrash, IconUpload } from '@tabler/icons-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+
+import { restaurantMenuItems, type RestaurantMenuItem } from '../mock-data'
+
+const availabilityOptions = ['AVAILABLE', 'UNAVAILABLE'] as const
+
+type AvailabilityOption = (typeof availabilityOptions)[number]
+
+const newItemSchema = z.object({
+  name: z.string().min(2, 'Enter at least two characters'),
+  price: z
+    .string()
+    .min(1, 'Required')
+    .regex(/^\d+(\.\d{1,2})?$/, 'Use numbers with up to 2 decimals'),
+  availability: z.enum(availabilityOptions),
+  imageUrl: z
+    .string()
+    .trim()
+    .transform((value) => (value.length ? value : undefined))
+    .optional(),
+  description: z
+    .string()
+    .trim()
+    .max(160, 'Keep descriptions under 160 characters')
+    .optional(),
+})
+
+type NewItemForm = z.infer<typeof newItemSchema>
+
+type EditableItem = RestaurantMenuItem & {
+  description?: string
+}
+
+const initialEditableItems: EditableItem[] = restaurantMenuItems.map((item) => ({
+  ...item,
+}))
+
+export function MenuManagementPanel() {
+  const [items, setItems] = useState<EditableItem[]>(initialEditableItems)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, EditableItem>>({})
+
+  const form = useForm<NewItemForm>({
+    resolver: zodResolver(newItemSchema),
+    defaultValues: {
+      name: '',
+      price: '',
+      availability: 'AVAILABLE',
+      imageUrl: '',
+      description: '',
+    },
+  })
+
+  const availabilityCounts = useMemo(
+    () =>
+      items.reduce(
+        (acc, item) => {
+          acc[item.availability] += 1
+          return acc
+        },
+        { AVAILABLE: 0, UNAVAILABLE: 0 } as Record<AvailabilityOption, number>,
+      ),
+    [items],
+  )
+
+  function handleSubmit(newItem: NewItemForm) {
+    const nextItem: EditableItem = {
+      id: `menu-${Math.random().toString(36).slice(-6)}`,
+      name: newItem.name,
+      price: Number(newItem.price),
+      availability: newItem.availability,
+      imageUrl: newItem.imageUrl,
+      description: newItem.description,
+    }
+
+    setItems((prev) => [nextItem, ...prev])
+    form.reset({
+      name: '',
+      price: '',
+      availability: 'AVAILABLE',
+      imageUrl: '',
+      description: '',
+    })
+  }
+
+  function toggleAvailability(id: string, value: boolean) {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              availability: value ? 'AVAILABLE' : 'UNAVAILABLE',
+            }
+          : item,
+      ),
+    )
+  }
+
+  function startEditing(item: EditableItem) {
+    setEditingId(item.id)
+    setDrafts((prev) => ({ ...prev, [item.id]: { ...item } }))
+  }
+
+  function cancelEditing(id: string) {
+    setDrafts((prev) => {
+      const next = { ...prev }
+      delete next[id]
+      return next
+    })
+    setEditingId((current) => (current === id ? null : current))
+  }
+
+  function updateDraft(id: string, key: keyof EditableItem, value: string) {
+    setDrafts((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        [key]: key === 'price' ? Number(value) : value,
+      } as EditableItem,
+    }))
+  }
+
+  function saveItem(id: string) {
+    const draft = drafts[id]
+    if (!draft || !draft.name.trim() || Number.isNaN(draft.price)) {
+      return
+    }
+    setItems((prev) => prev.map((item) => (item.id === id ? { ...draft } : item)))
+    cancelEditing(id)
+  }
+
+  function removeItem(id: string) {
+    if (items.length <= 1) {
+      return
+    }
+    if (confirm('Remove this item from the menu?')) {
+      setItems((prev) => prev.filter((item) => item.id !== id))
+    }
+  }
+
+  return (
+    <section id="menu-management" className="scroll-mt-28">
+      <Card className="border-emerald-100 bg-white/90 shadow-lg shadow-emerald-100/40">
+        <CardHeader className="space-y-3">
+          <CardTitle className="text-2xl font-semibold text-neutral-900">
+            Menu management
+          </CardTitle>
+          <p className="text-sm text-neutral-600">
+            Add dishes, update pricing, and control availability. Item details stay
+            aligned with FrontDash listing requirements.
+          </p>
+          <div className="flex flex-wrap gap-2 text-xs text-neutral-500">
+            <Badge
+              variant="outline"
+              className="border-emerald-200 bg-emerald-50 text-emerald-700"
+            >
+              {availabilityCounts.AVAILABLE} available
+            </Badge>
+            <Badge
+              variant="outline"
+              className="border-neutral-300 bg-neutral-100 text-neutral-700"
+            >
+              {availabilityCounts.UNAVAILABLE} unavailable
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="grid gap-4 rounded-2xl border border-emerald-100 bg-emerald-50/50 p-6 lg:grid-cols-[1.2fr_0.9fr_0.9fr_auto]"
+              noValidate
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem className="lg:col-span-1">
+                    <FormLabel>Item name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Grilled peach + burrata" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="price"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Price</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        placeholder="12.50"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Enter numbers only (FrontDash adds currency).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="availability"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Availability</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Choose status" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {availabilityOptions.map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {option}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-3 lg:col-span-4 lg:grid-cols-3">
+                <FormField
+                  control={form.control}
+                  name="imageUrl"
+                  render={({ field }) => (
+                    <FormItem className="lg:col-span-1">
+                      <FormLabel>Image URL (optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="https://…" {...field} />
+                      </FormControl>
+                      <FormDescription>
+                        Uploads arrive later—use a hosted link for now.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem className="lg:col-span-2">
+                      <FormLabel>Short description (optional)</FormLabel>
+                      <FormControl>
+                        <Textarea rows={2} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex items-end justify-end lg:col-span-3">
+                  <Button type="submit" className="gap-2">
+                    <IconPlus className="size-4" />
+                    Add dish
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </Form>
+
+          <div className="space-y-3">
+            {items.map((item) => {
+              const isEditing = editingId === item.id
+              const draft = drafts[item.id] ?? item
+
+              return (
+                <div
+                  key={item.id}
+                  className="grid gap-4 rounded-2xl border border-emerald-100 bg-white/90 p-5 shadow-sm shadow-emerald-50/40 lg:grid-cols-[1.5fr_1fr_1fr_auto] lg:items-start"
+                >
+                  <div className="space-y-2">
+                    {isEditing ? (
+                      <Input
+                        value={draft.name}
+                        onChange={(event) =>
+                          updateDraft(item.id, 'name', event.target.value)
+                        }
+                        placeholder="Dish name"
+                      />
+                    ) : (
+                      <p className="text-base font-semibold text-neutral-900">
+                        {item.name}
+                      </p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+                      {item.imageUrl ? (
+                        <span className="inline-flex items-center gap-1 text-neutral-500">
+                          <IconUpload className="size-4" />
+                          Image attached
+                        </span>
+                      ) : (
+                        <span className="text-neutral-400">No image yet</span>
+                      )}
+                      {item.description && !isEditing ? (
+                        <span>• {item.description}</span>
+                      ) : null}
+                    </div>
+                    {isEditing ? (
+                      <Textarea
+                        rows={2}
+                        value={draft.description ?? ''}
+                        onChange={(event) =>
+                          updateDraft(item.id, 'description', event.target.value)
+                        }
+                        placeholder="Add a short description"
+                        className="mt-2"
+                      />
+                    ) : null}
+                  </div>
+
+                  <div className="space-y-2">
+                    <span className="text-xs uppercase tracking-[0.18em] text-neutral-500">
+                      Price
+                    </span>
+                    {isEditing ? (
+                      <Input
+                        type="number"
+                        step="0.01"
+                        value={draft.price ?? 0}
+                        onChange={(event) =>
+                          updateDraft(item.id, 'price', event.target.value)
+                        }
+                      />
+                    ) : (
+                      <p className="font-semibold text-neutral-900">
+                        ${item.price.toFixed(2)}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <span className="text-xs uppercase tracking-[0.18em] text-neutral-500">
+                      Availability
+                    </span>
+                    <div className="flex items-center gap-3">
+                      <Switch
+                        checked={item.availability === 'AVAILABLE'}
+                        onCheckedChange={(value) => toggleAvailability(item.id, value)}
+                      />
+                      <Badge
+                        variant="outline"
+                        className={
+                          item.availability === 'AVAILABLE'
+                            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                            : 'border-neutral-300 bg-neutral-100 text-neutral-600'
+                        }
+                      >
+                        {item.availability}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-2 lg:items-end">
+                    {isEditing ? (
+                      <div className="flex gap-2">
+                        <Button size="sm" onClick={() => saveItem(item.id)}>
+                          Save
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => cancelEditing(item.id)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => startEditing(item)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:bg-destructive/10"
+                          onClick={() => removeItem(item.id)}
+                          disabled={items.length <= 1}
+                        >
+                          <IconTrash className="size-4" />
+                          <span className="sr-only">Remove</span>
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/restaurant/dashboard/components/nav-documents.tsx
+++ b/app/restaurant/dashboard/components/nav-documents.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  IconDots,
+  IconFolder,
+  IconShare3,
+  IconTrash,
+  type Icon,
+} from '@tabler/icons-react'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+
+export function NavDocuments({
+  items,
+}: {
+  items: {
+    name: string
+    url: string
+    icon: Icon
+  }[]
+}) {
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+      <SidebarGroupLabel>Resources</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <SidebarMenuItem key={item.name}>
+            <SidebarMenuButton asChild>
+              <Link href={item.url} className="flex items-center gap-2">
+                <item.icon className="size-4" />
+                <span>{item.name}</span>
+              </Link>
+            </SidebarMenuButton>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuAction
+                  showOnHover
+                  className="data-[state=open]:bg-accent rounded-sm"
+                >
+                  <IconDots />
+                  <span className="sr-only">More</span>
+                </SidebarMenuAction>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-24 rounded-lg"
+                side={isMobile ? 'bottom' : 'right'}
+                align={isMobile ? 'end' : 'start'}
+              >
+                <DropdownMenuItem>
+                  <IconFolder />
+                  <span>Open</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <IconShare3 />
+                  <span>Share</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive">
+                  <IconTrash />
+                  <span>Remove</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        ))}
+        <SidebarMenuItem>
+          <SidebarMenuButton className="text-sidebar-foreground/70">
+            <IconDots className="text-sidebar-foreground/70" />
+            <span>More</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/app/restaurant/dashboard/components/nav-main.tsx
+++ b/app/restaurant/dashboard/components/nav-main.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link from 'next/link'
+import { type Icon } from '@tabler/icons-react'
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar'
+
+export function NavMain({
+  items,
+}: {
+  items: {
+    title: string
+    url: string
+    icon?: Icon
+    badge?: string
+  }[]
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {items.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton asChild tooltip={item.title}>
+                <Link href={item.url} className="flex items-center gap-2">
+                  {item.icon && <item.icon className="size-4" />}
+                  <span>{item.title}</span>
+                  {item.badge ? (
+                    <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700">
+                      {item.badge}
+                    </span>
+                  ) : null}
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  )
+}

--- a/app/restaurant/dashboard/components/nav-secondary.tsx
+++ b/app/restaurant/dashboard/components/nav-secondary.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+import * as React from 'react'
+import { type Icon } from '@tabler/icons-react'
+
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar'
+
+export function NavSecondary({
+  items,
+  ...props
+}: {
+  items: {
+    title: string
+    url: string
+    icon: Icon
+  }[]
+} & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
+  return (
+    <SidebarGroup {...props}>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {items.map((item) => (
+            <SidebarMenuItem key={item.title}>
+              <SidebarMenuButton asChild>
+                <Link href={item.url} className="flex items-center gap-2">
+                  <item.icon className="size-4" />
+                  <span>{item.title}</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+          {/* Theme toggle intentionally omitted until global theming is configured. */}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  )
+}

--- a/app/restaurant/dashboard/components/nav-user.tsx
+++ b/app/restaurant/dashboard/components/nav-user.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import {
+  IconCreditCard,
+  IconDotsVertical,
+  IconLogout,
+  IconNotification,
+  IconUserCircle,
+} from '@tabler/icons-react'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+import { useLogoutRedirect } from '../hooks/use-logout'
+
+export function NavUser({
+  user,
+}: {
+  user: {
+    name: string
+    email: string
+    avatar: string
+  }
+}) {
+  const { isMobile } = useSidebar()
+  const logout = useLogoutRedirect()
+
+  function handleLogout(event?: Event) {
+    event?.preventDefault()
+    logout()
+  }
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <Avatar className="h-8 w-8 rounded-lg grayscale">
+                <AvatarImage src={user.avatar} alt={user.name} />
+                <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+              </Avatar>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">{user.name}</span>
+                <span className="text-muted-foreground truncate text-xs">
+                  {user.email}
+                </span>
+              </div>
+              <IconDotsVertical className="ml-auto size-4" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+            side={isMobile ? 'bottom' : 'right'}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="p-0 font-normal">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                <Avatar className="h-8 w-8 rounded-lg">
+                  <AvatarImage src={user.avatar} alt={user.name} />
+                  <AvatarFallback className="rounded-lg">CN</AvatarFallback>
+                </Avatar>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{user.name}</span>
+                  <span className="text-muted-foreground truncate text-xs">
+                    {user.email}
+                  </span>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <IconUserCircle />
+                Account
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <IconCreditCard />
+                Billing
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <IconNotification />
+                Notifications
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleLogout}>
+              <IconLogout />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/app/restaurant/dashboard/components/operating-hours-panel.tsx
+++ b/app/restaurant/dashboard/components/operating-hours-panel.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { IconClock, IconCopy } from '@tabler/icons-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+
+import { restaurantHoursTemplate, type RestaurantHours } from '../mock-data'
+
+const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+
+export function OperatingHoursPanel() {
+  const [hours, setHours] = useState<RestaurantHours[]>(restaurantHoursTemplate)
+
+  const openCount = useMemo(() => hours.filter((entry) => entry.isOpen).length, [hours])
+
+  function updateHours(day: string, patch: Partial<Omit<RestaurantHours, 'day'>>) {
+    setHours((prev) =>
+      prev.map((entry) => (entry.day === day ? { ...entry, ...patch } : entry)),
+    )
+  }
+
+  function copyWeekdayTemplate() {
+    const monday = hours.find((entry) => entry.day === 'Monday')
+    if (!monday) return
+    setHours((prev) =>
+      prev.map((entry) =>
+        weekdays.includes(entry.day)
+          ? {
+              ...entry,
+              isOpen: monday.isOpen,
+              open: monday.open,
+              close: monday.close,
+            }
+          : entry,
+      ),
+    )
+  }
+
+  return (
+    <section id="operating-hours" className="scroll-mt-28">
+      <Card className="border-emerald-100 bg-white/90 shadow-lg shadow-emerald-100/40">
+        <CardHeader className="space-y-3">
+          <CardTitle className="text-2xl font-semibold text-neutral-900">
+            Operating hours
+          </CardTitle>
+          <p className="text-sm text-neutral-600">
+            Keep availability accurate for dispatch. Update day-by-day or copy weekday
+            templates when the schedule is stable.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+            <Badge
+              variant="outline"
+              className="border-emerald-200 bg-emerald-50 text-emerald-700"
+            >
+              <IconClock className="size-4" /> {openCount} days open
+            </Badge>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1"
+              onClick={copyWeekdayTemplate}
+            >
+              <IconCopy className="size-4" /> Apply Monday to weekdays
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 lg:grid-cols-2">
+            {hours.map((entry) => (
+              <div
+                key={entry.day}
+                className="rounded-2xl border border-emerald-100 bg-white/90 p-4 shadow-sm shadow-emerald-50/40"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-neutral-900">{entry.day}</p>
+                    <p className="text-xs text-neutral-500">
+                      {entry.isOpen
+                        ? 'Visible to customers during these hours.'
+                        : 'Marked closed for this day.'}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={entry.isOpen}
+                    onCheckedChange={(value) => updateHours(entry.day, { isOpen: value })}
+                  />
+                </div>
+                {entry.isOpen ? (
+                  <div className="mt-4 grid grid-cols-2 gap-3">
+                    <div>
+                      <span className="text-xs uppercase tracking-[0.18em] text-neutral-500">
+                        Opens
+                      </span>
+                      <Input
+                        type="time"
+                        value={entry.open}
+                        onChange={(event) =>
+                          updateHours(entry.day, { open: event.target.value })
+                        }
+                      />
+                    </div>
+                    <div>
+                      <span className="text-xs uppercase tracking-[0.18em] text-neutral-500">
+                        Closes
+                      </span>
+                      <Input
+                        type="time"
+                        value={entry.close}
+                        onChange={(event) =>
+                          updateHours(entry.day, { close: event.target.value })
+                        }
+                      />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/restaurant/dashboard/components/orders-table.tsx
+++ b/app/restaurant/dashboard/components/orders-table.tsx
@@ -1,0 +1,389 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useId, useMemo, useState } from 'react'
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  type Row,
+  useReactTable,
+} from '@tanstack/react-table'
+import { IconChevronLeft, IconChevronRight, IconGripVertical } from '@tabler/icons-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+export type RestaurantOrder = {
+  id: string
+  placedAt: string
+  items: string
+  customer: string
+  status: 'NEW' | 'PREPARING' | 'READY' | 'COMPLETED'
+}
+
+const statusTone: Record<RestaurantOrder['status'], string> = {
+  NEW: 'border-emerald-200 bg-emerald-100 text-emerald-700',
+  PREPARING: 'border-amber-200 bg-amber-100 text-amber-800',
+  READY: 'border-sky-200 bg-sky-100 text-sky-700',
+  COMPLETED: 'border-neutral-300 bg-neutral-200 text-neutral-700',
+}
+
+type OrdersTableProps = {
+  orders: RestaurantOrder[]
+  variant?: 'preview' | 'full'
+  previewCount?: number
+  fullPageSize?: number
+}
+
+function DraggableRow({ row }: { row: Row<RestaurantOrder> }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: row.original.id,
+  })
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      data-dragging={isDragging}
+      className="relative z-0 data-[dragging=true]:z-10 data-[dragging=true]:shadow-lg data-[dragging=true]:opacity-80"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+    >
+      {row.getVisibleCells().map((cell) => {
+        if (cell.column.id === 'drag') {
+          return (
+            <TableCell key={cell.id} className="w-10">
+              <Button
+                ref={setActivatorNodeRef}
+                variant="ghost"
+                size="icon"
+                className="size-8 text-neutral-400 hover:text-neutral-700"
+                {...attributes}
+                {...listeners}
+              >
+                <IconGripVertical className="size-4" />
+                <span className="sr-only">Reorder row</span>
+              </Button>
+            </TableCell>
+          )
+        }
+
+        return (
+          <TableCell
+            key={cell.id}
+            className={cell.column.id === 'items' ? 'align-top' : undefined}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
+        )
+      })}
+    </TableRow>
+  )
+}
+
+export function OrdersTable({
+  orders,
+  variant = 'preview',
+  previewCount = 5,
+  fullPageSize = 8,
+}: OrdersTableProps) {
+  const isFull = variant === 'full'
+  const targetPageSize = isFull
+    ? fullPageSize
+    : Math.min(previewCount, orders.length || previewCount)
+
+  const [data, setData] = useState<RestaurantOrder[]>(
+    isFull ? orders : orders.slice(0, previewCount),
+  )
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: targetPageSize })
+
+  useEffect(() => {
+    setData(isFull ? orders : orders.slice(0, previewCount))
+    setPagination({ pageIndex: 0, pageSize: targetPageSize })
+  }, [orders, previewCount, targetPageSize, isFull])
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 100, tolerance: 8 } }),
+    useSensor(KeyboardSensor),
+  )
+
+  const columns = useMemo<ColumnDef<RestaurantOrder>[]>(
+    () => [
+      {
+        id: 'drag',
+        header: () => null,
+        cell: () => null,
+        enableSorting: false,
+        enableHiding: false,
+        size: 40,
+      },
+      {
+        accessorKey: 'id',
+        header: 'Order',
+        cell: ({ row }) => (
+          <div className="flex flex-col">
+            <span className="font-semibold text-neutral-900">{row.original.id}</span>
+            <span className="text-xs text-neutral-500">
+              Placed {row.original.placedAt}
+            </span>
+          </div>
+        ),
+        enableSorting: false,
+      },
+      {
+        accessorKey: 'items',
+        header: 'Items',
+        cell: ({ row }) => (
+          <span className="text-sm text-neutral-700">{row.original.items}</span>
+        ),
+      },
+      {
+        accessorKey: 'customer',
+        header: 'Customer',
+        cell: ({ row }) => (
+          <span className="text-sm text-neutral-700">{row.original.customer}</span>
+        ),
+      },
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        cell: ({ row }) => (
+          <Badge
+            variant="outline"
+            className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.12em] ${statusTone[row.original.status]}`}
+          >
+            {row.original.status}
+          </Badge>
+        ),
+        enableSorting: false,
+      },
+    ],
+    [],
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      pagination,
+    },
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) {
+      return
+    }
+
+    setData((prev) => {
+      const oldIndex = prev.findIndex((order) => order.id === active.id)
+      const newIndex = prev.findIndex((order) => order.id === over.id)
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return prev
+      }
+
+      return arrayMove(prev, oldIndex, newIndex)
+    })
+  }
+
+  const pageCount = table.getPageCount()
+  const currentPage = table.getState().pagination.pageIndex + 1
+  const totalPages = pageCount > 0 ? pageCount : 1
+  const rowModel = table.getRowModel()
+  const currentPageIds = rowModel.rows.map((row) => row.original.id)
+  const sortableId = useId()
+
+  return (
+    <Card
+      id="order-queue"
+      className={`flex flex-col border-emerald-100 bg-white/90 shadow-lg shadow-emerald-100/40 ${
+        isFull ? 'min-h-[70vh]' : 'min-h-[320px]'
+      }`}
+    >
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-2xl font-semibold text-neutral-900">
+          Live order queue
+        </CardTitle>
+        <p className="text-sm text-neutral-600">
+          Drag rows to reprioritize kitchen prep.{' '}
+          {isFull
+            ? 'Pagination keeps the view tidy once the queue grows.'
+            : 'Open the full queue to manage every ticket.'}
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-6">
+        <div className="flex-1 overflow-hidden rounded-2xl border border-emerald-100 bg-white">
+          <DndContext
+            id={sortableId}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToVerticalAxis]}
+            onDragEnd={handleDragEnd}
+            sensors={sensors}
+          >
+            <Table>
+              <TableHeader className="sticky top-0 z-10 bg-emerald-50/90">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {rowModel.rows.length ? (
+                  <SortableContext
+                    items={currentPageIds}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    {rowModel.rows.map((row) => (
+                      <DraggableRow key={row.id} row={row} />
+                    ))}
+                  </SortableContext>
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      className="h-24 text-center text-sm text-neutral-500"
+                    >
+                      No orders in the queue.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </DndContext>
+        </div>
+        {isFull ? (
+          <div className="flex flex-col gap-4 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-xs text-neutral-500 sm:text-sm">
+              Changes are local previews until the real-time order API ships.
+            </span>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
+              <div className="flex items-center gap-2">
+                <span className="text-xs uppercase tracking-[0.18em] text-neutral-500 sm:text-sm">
+                  Rows per page
+                </span>
+                <Select
+                  value={`${table.getState().pagination.pageSize}`}
+                  onValueChange={(value) => table.setPageSize(Number(value))}
+                >
+                  <SelectTrigger
+                    className="h-9 w-[90px] bg-white"
+                    aria-label="Rows per page"
+                  >
+                    <SelectValue
+                      placeholder={`${table.getState().pagination.pageSize}`}
+                    />
+                  </SelectTrigger>
+                  <SelectContent side="top">
+                    {[4, 6, 8, 10, 12].map((pageSize) => (
+                      <SelectItem key={pageSize} value={`${pageSize}`}>
+                        {pageSize}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center justify-between gap-3 sm:gap-4">
+                <span className="text-xs uppercase tracking-[0.18em] text-neutral-500 sm:text-sm">
+                  Page {Math.min(currentPage, totalPages)} of {totalPages}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                  >
+                    <span className="sr-only">Previous page</span>
+                    <IconChevronLeft className="size-4" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
+                  >
+                    <span className="sr-only">Next page</span>
+                    <IconChevronRight className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-xs text-neutral-500 sm:text-sm">
+              Showing the five most recent orders. Drag to flag urgent tickets before the
+              handoff.
+            </span>
+            <Button asChild variant="outline" className="sm:w-auto">
+              <Link href="/restaurant/dashboard/order-queue">Open full order queue</Link>
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/restaurant/dashboard/components/site-header.tsx
+++ b/app/restaurant/dashboard/components/site-header.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { SidebarTrigger } from '@/components/ui/sidebar'
+import { useLogoutRedirect } from '../hooks/use-logout'
+
+export function RestaurantHeader() {
+  const logout = useLogoutRedirect()
+
+  return (
+    <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-white/60 backdrop-blur-md transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
+      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+        <SidebarTrigger className="-ml-1" />
+        <Separator
+          orientation="vertical"
+          className="mx-2 data-[orientation=vertical]:h-4"
+        />
+        <div className="flex flex-col">
+          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-600">
+            Restaurant portal
+          </span>
+          <h1 className="text-base font-medium">Citrus &amp; Thyme</h1>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-emerald-200 text-emerald-600 hover:bg-emerald-50"
+            onClick={logout}
+          >
+            Logout
+          </Button>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/app/restaurant/dashboard/components/withdraw-request-card.tsx
+++ b/app/restaurant/dashboard/components/withdraw-request-card.tsx
@@ -1,0 +1,328 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+
+const withdrawalReasonValues = ['seasonal', 'permanent', 'pause', 'service'] as const
+
+type WithdrawalReason = (typeof withdrawalReasonValues)[number]
+
+const withdrawalReasonLabels: Record<WithdrawalReason, string> = {
+  seasonal: 'Seasonal or temporary closure',
+  permanent: 'Permanent departure from FrontDash',
+  pause: 'Short-term pause for renovations or events',
+  service: 'Service or payout issue',
+}
+
+const withdrawSchema = z.object({
+  effectiveDate: z.string().min(1, 'Select an effective date'),
+  reason: z.enum(withdrawalReasonValues, {
+    required_error: 'Pick the closest reason for your request',
+  }),
+  details: z.string().min(16, 'Share at least a short sentence so our team has context'),
+  acknowledgement: z.literal(true, {
+    errorMap: () => ({
+      message: 'Please confirm there are no open orders or unpaid balances',
+    }),
+  }),
+})
+
+type WithdrawFormValues = z.infer<typeof withdrawSchema>
+
+type QueuedRequest = {
+  reference: string
+  effectiveDate: string
+  reason: WithdrawalReason
+  details: string
+  submittedAt: string
+}
+
+function formatDateLabel(value: string) {
+  if (!value) return 'TBD'
+  const parsed = new Date(`${value}T00:00:00`)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function generateReference() {
+  return `WDR-${Math.random().toString(36).slice(-5).toUpperCase()}`
+}
+
+export function WithdrawRequestCard() {
+  const form = useForm<WithdrawFormValues>({
+    resolver: zodResolver(withdrawSchema),
+    defaultValues: {
+      effectiveDate: '',
+      reason: undefined,
+      details: '',
+      acknowledgement: false,
+    },
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [queuedRequest, setQueuedRequest] = useState<QueuedRequest | null>(null)
+
+  const reasonOptions = useMemo(
+    () =>
+      withdrawalReasonValues.map((value) => ({
+        value,
+        label: withdrawalReasonLabels[value],
+      })),
+    [],
+  )
+
+  async function onSubmit(values: WithdrawFormValues) {
+    setIsSubmitting(true)
+    await new Promise((resolve) => setTimeout(resolve, 800))
+
+    const reference = generateReference()
+    const submittedAt = new Date().toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+
+    setQueuedRequest({
+      reference,
+      ...values,
+      submittedAt,
+    })
+    setIsSubmitting(false)
+    form.reset({
+      effectiveDate: '',
+      reason: undefined,
+      details: '',
+      acknowledgement: false,
+    })
+  }
+
+  return (
+    <section id="withdrawal" className="scroll-mt-28">
+      <Card className="border-emerald-100 bg-white/90 shadow-lg shadow-emerald-100/40">
+        <CardHeader className="space-y-3">
+          <Badge
+            variant="outline"
+            className="w-fit border-amber-200 bg-amber-100 text-amber-700"
+          >
+            <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em]">
+              <IconAlertTriangle className="size-4" />
+              Withdrawal queue
+            </span>
+          </Badge>
+          <CardTitle className="text-2xl font-semibold text-neutral-900">
+            Withdraw from FrontDash
+          </CardTitle>
+          <p className="text-sm text-neutral-600">
+            Let the FrontDash ops team know when you plan to step away. We&apos;ll queue
+            the request for review and send a confirmation once everything is cleared.
+          </p>
+        </CardHeader>
+        <CardContent className="pb-8">
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="grid gap-6 lg:grid-cols-[2fr_1fr] lg:items-start"
+              noValidate
+            >
+              <div className="space-y-6">
+                <FormField
+                  control={form.control}
+                  name="effectiveDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Desired effective date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="date"
+                          className="w-full"
+                          min={new Date().toISOString().split('T')[0]}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        We recommend giving at least 48 hours for the approval queue.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="reason"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>What best describes this withdrawal?</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Choose a reason" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {reasonOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        The admin dashboard groups requests by reason to speed up triage.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="details"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Share any helpful context</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={4}
+                          placeholder="We're pausing for the winter farmers market season..."
+                          className="resize-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Include pickup schedule changes, pending payouts, or anything the
+                        admin should double-check.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="acknowledgement"
+                  render={({ field }) => (
+                    <FormItem className="rounded-2xl border border-emerald-100 bg-emerald-50/40 p-4">
+                      <div className="flex items-start gap-3">
+                        <FormControl>
+                          <Checkbox
+                            id="withdraw-acknowledge"
+                            checked={field.value}
+                            onCheckedChange={(checked) => field.onChange(!!checked)}
+                          />
+                        </FormControl>
+                        <div className="space-y-1">
+                          <FormLabel
+                            htmlFor="withdraw-acknowledge"
+                            className="font-semibold"
+                          >
+                            Confirm the kitchen is clear
+                          </FormLabel>
+                          <FormDescription>
+                            Outstanding orders are fulfilled, payouts are reconciled, and
+                            staff know about the request.
+                          </FormDescription>
+                        </div>
+                      </div>
+                      <FormMessage className="mt-2" />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="flex flex-col gap-2 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
+                  <span className="text-xs text-neutral-500 sm:text-sm">
+                    Requests land in the admin withdrawal queue within a minute.
+                  </span>
+                  <Button type="submit" disabled={isSubmitting} className="sm:w-auto">
+                    {isSubmitting ? 'Submitting…' : 'Submit withdrawal request'}
+                  </Button>
+                </div>
+              </div>
+
+              <aside className="space-y-4 rounded-2xl border border-emerald-100 bg-emerald-50/70 p-5 text-sm text-neutral-700">
+                {queuedRequest ? (
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
+                        Request queued
+                      </p>
+                      <p className="text-xs text-neutral-500">
+                        Reference {queuedRequest.reference} • Submitted{' '}
+                        {queuedRequest.submittedAt}
+                      </p>
+                    </div>
+                    <dl className="space-y-2 text-xs text-neutral-600">
+                      <div className="flex items-center justify-between gap-4">
+                        <dt className="font-medium text-neutral-700">Effective</dt>
+                        <dd>{formatDateLabel(queuedRequest.effectiveDate)}</dd>
+                      </div>
+                      <div className="flex items-center justify-between gap-4">
+                        <dt className="font-medium text-neutral-700">Reason</dt>
+                        <dd>{withdrawalReasonLabels[queuedRequest.reason]}</dd>
+                      </div>
+                    </dl>
+                    <div>
+                      <p className="text-xs font-medium text-neutral-700">
+                        Notes for admins
+                      </p>
+                      <p className="mt-1 rounded-lg bg-white/80 p-3 text-xs text-neutral-600">
+                        {queuedRequest.details}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
+                      What to expect
+                    </p>
+                    <ul className="space-y-2 text-xs text-neutral-600">
+                      <li>• Admins verify payouts before approving or denying.</li>
+                      <li>
+                        • You&apos;ll receive an email once the decision is made (usually
+                        within 48 hours).
+                      </li>
+                      <li>
+                        • If payments are due, support will reach out with next steps.
+                      </li>
+                    </ul>
+                  </div>
+                )}
+              </aside>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/app/restaurant/dashboard/hooks/use-logout.ts
+++ b/app/restaurant/dashboard/hooks/use-logout.ts
@@ -1,0 +1,16 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+export function useLogoutRedirect() {
+  const router = useRouter()
+
+  return useCallback(() => {
+    router.push('/')
+    // TODO: replace with real auth sign-out once backend is wired up.
+    // Example:
+    // await authClient.signOut();
+    // router.push('/');
+  }, [router])
+}

--- a/app/restaurant/dashboard/layout.tsx
+++ b/app/restaurant/dashboard/layout.tsx
@@ -1,0 +1,27 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
+
+import { RestaurantSidebar } from './components/app-sidebar'
+import { RestaurantHeader } from './components/site-header'
+
+export default function RestaurantDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <SidebarProvider
+      defaultOpen
+      style={
+        {
+          '--sidebar-width': 'calc(var(--spacing) * 68)',
+        } as CSSProperties
+      }
+    >
+      <RestaurantSidebar variant="inset" />
+      <SidebarInset>
+        <RestaurantHeader />
+        <div className="flex flex-1 flex-col bg-gradient-to-br from-emerald-50 via-white to-sky-50">
+          <div className="flex-1 px-4 pb-6 pt-4 lg:px-8 lg:pb-10 lg:pt-6">{children}</div>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}

--- a/app/restaurant/dashboard/mock-data.ts
+++ b/app/restaurant/dashboard/mock-data.ts
@@ -1,0 +1,155 @@
+import { type RestaurantOrder } from './components/orders-table'
+
+export type RestaurantInsight = {
+  label: string
+  value: string
+  helper: string
+}
+
+export type RestaurantMenuItem = {
+  id: string
+  name: string
+  price: number
+  availability: 'AVAILABLE' | 'UNAVAILABLE'
+  imageUrl?: string
+}
+
+export type RestaurantHours = {
+  day: string
+  isOpen: boolean
+  open: string
+  close: string
+}
+
+export type RestaurantContactDetails = {
+  contactPerson: string
+  email: string
+  phoneNumbers: string[]
+  street: string
+  city: string
+  state: string
+  postalCode: string
+  suite?: string
+}
+
+export const restaurantInsights: RestaurantInsight[] = [
+  {
+    label: 'Orders waiting for prep',
+    value: '3',
+    helper: 'Prioritize newest FrontDash tickets first',
+  },
+  {
+    label: 'Average prep time today',
+    value: '17 min',
+    helper: 'Goal: keep under 20 minutes for delivery SLAs',
+  },
+  {
+    label: 'FrontDash rating (mock)',
+    value: '4.8 ★',
+    helper: 'Reviews go live once the feedback API ships',
+  },
+]
+
+export const restaurantOrders: RestaurantOrder[] = [
+  {
+    id: '#ORD-4312',
+    placedAt: '12:52 PM',
+    items: '2 × Citrus roasted chicken · 1 × Bright fennel salad',
+    customer: 'Alex Chen',
+    status: 'NEW',
+  },
+  {
+    id: '#ORD-4311',
+    placedAt: '12:37 PM',
+    items: '1 × Herb focaccia · 3 × Whipped feta jars',
+    customer: 'Jordan Ellis',
+    status: 'PREPARING',
+  },
+  {
+    id: '#ORD-4310',
+    placedAt: '12:14 PM',
+    items: '2 × Summer risotto · 2 × Lemon sorbet',
+    customer: 'Priya Nair',
+    status: 'PREPARING',
+  },
+  {
+    id: '#ORD-4309',
+    placedAt: '11:58 AM',
+    items: '1 × Charred broccolini · 1 × Olive oil cake',
+    customer: 'Chris Wallace',
+    status: 'READY',
+  },
+  {
+    id: '#ORD-4308',
+    placedAt: '11:35 AM',
+    items: '3 × Smoky tomato bisque',
+    customer: 'Morgan Lake',
+    status: 'COMPLETED',
+  },
+  {
+    id: '#ORD-4307',
+    placedAt: '11:20 AM',
+    items: '4 × Roasted beet tartines',
+    customer: 'Taylor Brooks',
+    status: 'READY',
+  },
+  {
+    id: '#ORD-4306',
+    placedAt: '11:05 AM',
+    items: '1 × Farro grain bowl · 2 × Blackberry mousse',
+    customer: 'Jamie Rivera',
+    status: 'COMPLETED',
+  },
+  {
+    id: '#ORD-4305',
+    placedAt: '10:52 AM',
+    items: '3 × Smoked paprika cauliflower',
+    customer: 'Lee Gardner',
+    status: 'COMPLETED',
+  },
+]
+
+export const restaurantMenuItems: RestaurantMenuItem[] = [
+  {
+    id: 'menu-olive-oil-cake',
+    name: 'Olive oil citrus cake',
+    price: 9.5,
+    availability: 'AVAILABLE',
+    imageUrl: '/images/menu/olive-oil-cake.png',
+  },
+  {
+    id: 'menu-braised-fennel',
+    name: 'Braised fennel + burrata',
+    price: 14,
+    availability: 'AVAILABLE',
+    imageUrl: '/images/menu/braised-fennel.png',
+  },
+  {
+    id: 'menu-citrus-chicken',
+    name: 'Citrus roasted chicken',
+    price: 18,
+    availability: 'UNAVAILABLE',
+    imageUrl: '/images/menu/citrus-chicken.png',
+  },
+]
+
+export const restaurantHoursTemplate: RestaurantHours[] = [
+  { day: 'Monday', isOpen: true, open: '10:00', close: '21:00' },
+  { day: 'Tuesday', isOpen: true, open: '10:00', close: '21:00' },
+  { day: 'Wednesday', isOpen: true, open: '10:00', close: '21:00' },
+  { day: 'Thursday', isOpen: true, open: '10:00', close: '22:00' },
+  { day: 'Friday', isOpen: true, open: '10:00', close: '23:00' },
+  { day: 'Saturday', isOpen: true, open: '09:00', close: '23:00' },
+  { day: 'Sunday', isOpen: false, open: '00:00', close: '00:00' },
+]
+
+export const restaurantContact: RestaurantContactDetails = {
+  contactPerson: 'Morgan Ellis',
+  email: 'ops@citrusandthyme.com',
+  phoneNumbers: ['5125550198', '5125550103'],
+  street: '410 Market Street',
+  suite: 'Suite B',
+  city: 'Austin',
+  state: 'TX',
+  postalCode: '78704',
+}

--- a/app/restaurant/dashboard/order-queue/page.tsx
+++ b/app/restaurant/dashboard/order-queue/page.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { OrdersTable } from '../components/orders-table'
+import { restaurantInsights, restaurantOrders } from '../mock-data'
+
+export default function RestaurantOrderQueuePage() {
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-4 pb-16 pt-6 lg:px-8">
+      <section className="rounded-3xl border border-emerald-100 bg-white/90 p-8 shadow-lg shadow-emerald-100/40">
+        <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-start">
+          <div className="space-y-3">
+            <CardTitle className="text-3xl font-semibold text-neutral-900">
+              Live order queue
+            </CardTitle>
+            <p className="text-sm text-neutral-600 lg:text-base">
+              Drag rows to reprioritize tickets as they come in. Pagination keeps the full
+              queue manageable once the kitchen is slammed.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {restaurantInsights.map((item) => (
+              <Card
+                key={item.label}
+                className="border border-emerald-100 bg-white/70 py-4 text-center shadow-none"
+              >
+                <CardHeader className="space-y-1">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-600">
+                    {item.label}
+                  </p>
+                  <CardTitle className="text-2xl font-semibold text-neutral-900">
+                    {item.value}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="text-xs text-neutral-500">
+                  {item.helper}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <OrdersTable orders={restaurantOrders} variant="full" fullPageSize={8} />
+    </div>
+  )
+}

--- a/app/restaurant/dashboard/page.tsx
+++ b/app/restaurant/dashboard/page.tsx
@@ -1,34 +1,64 @@
-import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { ContactDetailsCard } from './components/contact-details-card'
+import { MenuManagementPanel } from './components/menu-management-panel'
+import { OperatingHoursPanel } from './components/operating-hours-panel'
+import { OrdersTable } from './components/orders-table'
+import { WithdrawRequestCard } from './components/withdraw-request-card'
+import { restaurantInsights, restaurantOrders } from './mock-data'
 
 export default function RestaurantDashboardPage() {
   return (
-    <div className="min-h-screen bg-neutral-50 py-16">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-6">
-        <div className="space-y-3 text-center">
-          <Badge className="mx-auto w-fit rounded-full border border-rose-200 bg-rose-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-rose-600">
-            Restaurant portal (preview)
-          </Badge>
-          <h1 className="text-3xl font-semibold text-neutral-900">
-            Restaurant dashboard coming soon
-          </h1>
-          <p className="text-sm text-neutral-600">
-            We’ll surface live orders, menu management, and operating hours once the
-            backend integration is ready. For now, you can return to the homepage or
-            adjust your registration details.
-          </p>
+    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-4 pb-16 pt-6 lg:px-8">
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-200 via-emerald-100 to-sky-100 p-8 text-neutral-900 shadow-lg">
+        <div className="absolute inset-y-0 right-0 hidden w-1/2 rounded-l-3xl bg-white/25 backdrop-blur-lg lg:block" />
+        <div className="relative z-10 grid gap-6 lg:grid-cols-[1.3fr_1fr] lg:items-center">
+          <div className="space-y-4">
+            <span className="inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-700">
+              Today&apos;s shift
+            </span>
+            <h1 className="text-3xl font-semibold lg:text-4xl">
+              Welcome back, Citrus &amp; Thyme crew
+            </h1>
+            <p className="max-w-xl text-sm text-neutral-700 lg:text-base">
+              This dashboard keeps you aligned with everything FrontDash expects from
+              partner restaurants—live order tracking, menu upkeep, opening hours, and
+              account security.
+            </p>
+          </div>
+          <Card className="border-none bg-white/80 shadow-xl shadow-emerald-200/50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-semibold text-emerald-600 uppercase tracking-[0.3em]">
+                Snapshot
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-4">
+              {restaurantInsights.map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-2xl border border-emerald-100 bg-white/70 p-4"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-600">
+                    {item.label}
+                  </p>
+                  <p className="text-2xl font-semibold text-neutral-900">{item.value}</p>
+                  <p className="text-xs text-neutral-500">{item.helper}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
         </div>
-        <div className="flex flex-wrap items-center justify-center gap-3">
-          <Button variant="outline" asChild>
-            <Link href="/">Back to homepage</Link>
-          </Button>
-          <Button asChild>
-            <Link href="/register-restaurant">Submit another registration</Link>
-          </Button>
-        </div>
-      </div>
+      </section>
+
+      <OrdersTable orders={restaurantOrders} variant="preview" />
+
+      <div id="requirements" className="sr-only" aria-hidden />
+      <div id="delivery-checklist" className="sr-only" aria-hidden />
+
+      <MenuManagementPanel />
+      <OperatingHoursPanel />
+      <ContactDetailsCard />
+      <WithdrawRequestCard />
     </div>
   )
 }

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -49,7 +49,7 @@ This document contains all user stories derived from the FrontDash project requi
 
 ### Restaurant Management
 
-#### STORY-R004: Restaurant Login
+#### ✅ STORY-R004: Restaurant Login
 **As a** restaurant user  
 **I want to** login to my account  
 **So that** I can manage my restaurant
@@ -58,7 +58,7 @@ This document contains all user stories derived from the FrontDash project requi
 - Login with username and password (*"login"*)
 - Password must be masked/hidden (*"Passwords should never be displayed"*)
 
-#### STORY-R005: Change Password
+#### ✅ STORY-R005: Change Password
 **As a** restaurant user  
 **I want to** change my password  
 **So that** I can maintain account security


### PR DESCRIPTION
Summary

  - Replace the restaurant order queue with a drag-and-drop table (preview + full page) using shared mock data and pagination.
  - Add menu management, operating hours, contact details, and withdrawal request panels to cover the remaining restaurant portal requirements.
  - Wire the logout controls to route back to the landing page (with TODO for real auth), streamline sidebar navigation, and add reusable sidebar components.
  - Update README and user stories to reflect the implemented frontend features.