### PR TITLE
 Auth: unified login, staff first‑login enforcement, password change validation

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+type ApiResponse = { success: boolean; role?: 'admin' | 'staff'; message?: string }
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    const u = username.trim()
+    const p = password
+    if (!u || !p) {
+      setError('Enter username and password.')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch('/api/auth/sign-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: u, password: p }),
+      })
+      const data: ApiResponse = await res.json().catch(() => ({ success: false }))
+      if (!res.ok || !data.success || !data.role) {
+        setError(data.message || 'Invalid credentials')
+        return
+      }
+
+      localStorage.setItem('fd_username', u)
+      localStorage.setItem('fd_email', `${u}@frontdash.app`)
+      localStorage.setItem('fd_role', data.role)
+
+      if ((data.role || '').toLowerCase() === 'staff') {
+        const alreadyChanged = localStorage.getItem('fd_pwd_changed') === '1'
+        if (!alreadyChanged) {
+          localStorage.setItem('fd_must_change_pwd', '1')
+          try { sessionStorage.setItem('fd_temp_pwd', p) } catch {}
+        } else {
+          localStorage.removeItem('fd_must_change_pwd')
+          try { sessionStorage.removeItem('fd_temp_pwd') } catch {}
+        }
+      } else {
+        // Not staff — clear any stale flags
+        localStorage.removeItem('fd_must_change_pwd')
+        try { sessionStorage.removeItem('fd_temp_pwd') } catch {}
+      }
+
+      router.replace(data.role === 'admin' ? '/admin/dashboard' : '/staff')
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="grid min-h-screen grid-cols-1 bg-gradient-to-br from-muted/40 to-background md:grid-cols-2">
+      <div className="relative hidden items-center justify-center p-8 md:flex">
+        <div className="absolute inset-6 rounded-3xl bg-muted/40" />
+        <div className="relative z-10 max-w-md">
+          <div className="mb-4 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            FD
+          </div>
+          <h2 className="text-2xl font-semibold">Welcome to FrontDash</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Sign in to manage orders, staff, and drivers efficiently.
+          </p>
+        </div>
+      </div>
+
+      <main className="flex items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="mb-6">
+            <h1 className="text-xl font-semibold">Sign in</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Use your FrontDash account to continue.
+            </p>
+          </div>
+
+          <form onSubmit={onSubmit} className="rounded-xl border bg-background p-5 shadow-sm">
+            <div className="grid gap-3">
+              <label className="grid gap-1 text-sm">
+                <span className="text-muted-foreground">Username</span>
+                <input
+                  className="h-9 rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Enter username"
+                  autoComplete="username"
+                />
+              </label>
+              <label className="grid gap-1 text-sm">
+                <span className="text-muted-foreground">Password</span>
+                <input
+                  type="password"
+                  className="h-9 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter password"
+                  autoComplete="current-password"
+                />
+              </label>
+              {error && <div className="text-sm text-rose-600">{error}</div>}
+              <div className="pt-1">
+                <Button type="submit" className="w-full" disabled={loading}>
+                  {loading ? 'Signing in…' : 'Sign in'}
+                </Button>
+              </div>
+            </div>
+          </form>
+
+          <div className="mt-6 text-center text-xs text-muted-foreground">
+            <span>© {new Date().getFullYear()} FrontDash</span>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/(auth)/staff/first-login/page.tsx
+++ b/app/(auth)/staff/first-login/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * Staff First-Login (Temporary)
+ * - Redirects to /staff/settings so password can be changed first.
+ * - Safe to delete later if unused.
+ */
+import { redirect } from 'next/navigation'
+
+export default function StaffFirstLoginTemp() {
+  redirect('/staff/settings')
+}

--- a/app/(dashboard)/staff/layout.tsx
+++ b/app/(dashboard)/staff/layout.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { SidebarProvider, Sidebar, SidebarInset } from '@/components/ui/sidebar'
+import { AdminStoreProvider } from '../admin/_state/admin-store'
+import { StaffSidebar } from './components/staff-sidebar'
+import { StaffSiteHeader } from './components/site-header'
+import { Toaster } from 'sonner'
+
+export default function StaffLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const [collapsed, setCollapsed] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const v = typeof window !== 'undefined' ? localStorage.getItem('fd_sidebar_collapsed') : null
+    setCollapsed(v === '1')
+  }, [])
+
+  useEffect(() => {
+    // Enforce first-login password change for staff
+    const rawRole = typeof window !== 'undefined' ? localStorage.getItem('fd_role') : null
+    const role = (rawRole || '').toLowerCase()
+    const pwdChanged = typeof window !== 'undefined' ? localStorage.getItem('fd_pwd_changed') === '1' : false
+    const mustChangeFlag = typeof window !== 'undefined' ? localStorage.getItem('fd_must_change_pwd') === '1' : false
+
+    const mustChange = role === 'staff' && (!pwdChanged || mustChangeFlag)
+
+    const onSettings = pathname?.startsWith('/staff/settings')
+    if (mustChange && !onSettings) {
+      router.replace('/staff/settings')
+      setReady(true)
+      return
+    }
+
+    setReady(true)
+  }, [pathname, router])
+
+  function toggleSidebar() {
+    setCollapsed((c) => {
+      const next = !c
+      if (typeof window !== 'undefined') localStorage.setItem('fd_sidebar_collapsed', next ? '1' : '0')
+      return next
+    })
+  }
+
+  if (!ready) return null
+
+  return (
+    <SidebarProvider>
+      <AdminStoreProvider>
+        <Sidebar
+          variant="inset"
+          className={
+            (collapsed ? 'w-16 min-w-[4rem]' : 'w-64 min-w-[16rem]') +
+            ' overflow-hidden transition-[width] duration-200'
+          }
+        >
+          <StaffSidebar collapsed={collapsed} />
+        </Sidebar>
+        <SidebarInset>
+          <StaffSiteHeader collapsed={collapsed} onToggleSidebar={toggleSidebar} />
+          <main className="flex-1 p-4 md:p-6">
+            <div className="mx-auto w-full max-w-6xl">{children}</div>
+          </main>
+          <Toaster richColors position="top-right" />
+        </SidebarInset>
+      </AdminStoreProvider>
+    </SidebarProvider>
+  )
+}

--- a/app/(dashboard)/staff/settings/components/password-change-form.tsx
+++ b/app/(dashboard)/staff/settings/components/password-change-form.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import * as React from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, 'Enter your current (temporary) password'),
+    newPassword: z
+      .string()
+      .min(8, 'Must be at least 8 characters')
+      .regex(/[A-Z]/, 'Must include at least one uppercase letter')
+      .regex(/[a-z]/, 'Must include at least one lowercase letter')
+      .regex(/[0-9]/, 'Must include at least one number'),
+    confirmPassword: z.string().min(1, 'Confirm your new password'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    path: ['confirmPassword'],
+    message: 'Passwords do not match',
+  })
+  .refine((data) => data.newPassword !== data.currentPassword, {
+    path: ['newPassword'],
+    message: 'New password cannot be the same as current password',
+  })
+
+type FormValues = z.infer<typeof schema>
+
+export default function PasswordChangeForm({
+  onSuccessRedirect = '/staff',
+}: {
+  onSuccessRedirect?: string
+}) {
+  const router = useRouter()
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  })
+
+  async function onSubmit(values: FormValues) {
+    // Validate the current (temporary) password matches the one used at login
+    const temp = typeof window !== 'undefined' ? sessionStorage.getItem('fd_temp_pwd') : null
+    if (temp && values.currentPassword !== temp) {
+      setError('currentPassword', {
+        type: 'validate',
+        message: 'Current password does not match your temporary password',
+      })
+      return
+    }
+
+    try {
+      // If you add a backend later, POST to /api/staff/change-password
+      await new Promise((r) => setTimeout(r, 700))
+
+      // Success: mark as changed and clear enforcement flags
+      localStorage.setItem('fd_pwd_changed', '1')
+      localStorage.removeItem('fd_must_change_pwd')
+      try {
+        sessionStorage.removeItem('fd_temp_pwd')
+      } catch {}
+
+      toast.success('Password updated successfully')
+      reset()
+      router.replace(onSuccessRedirect)
+    } catch (e: unknown) {
+      const errorMessage =
+        typeof e === 'object' &&
+        e !== null &&
+        'message' in e &&
+        typeof (e as Record<string, unknown>).message === 'string'
+          ? (e as { message: string }).message
+          : 'Failed to change password'
+      toast.error(errorMessage)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border bg-background p-5 shadow-sm">
+      <h2 className="text-lg font-semibold">Change Password</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        You must set a new password before using Staff features.
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-4 space-y-3">
+        <div>
+          <label htmlFor="currentPassword" className="mb-1 block text-sm text-muted-foreground">
+            Current (temporary) password
+          </label>
+          <input
+            id="currentPassword"
+            type="password"
+            autoComplete="current-password"
+            className="h-9 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+            {...register('currentPassword')}
+          />
+          {errors.currentPassword && (
+            <p className="mt-1 text-sm text-rose-600">{errors.currentPassword.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="newPassword" className="mb-1 block text-sm text-muted-foreground">
+            New password
+          </label>
+          <input
+            id="newPassword"
+            type="password"
+            autoComplete="new-password"
+            className="h-9 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+            {...register('newPassword')}
+          />
+          {errors.newPassword && (
+            <p className="mt-1 text-sm text-rose-600">{errors.newPassword.message}</p>
+          )}
+          <p className="mt-1 text-xs text-muted-foreground">
+            Requirements: 8+ characters, at least 1 uppercase, 1 lowercase, and 1 number.
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="confirmPassword" className="mb-1 block text-sm text-muted-foreground">
+            Confirm new password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            className="h-9 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-2"
+            {...register('confirmPassword')}
+          />
+          {errors.confirmPassword && (
+            <p className="mt-1 text-sm text-rose-600">{errors.confirmPassword.message}</p>
+          )}
+        </div>
+
+        <div className="pt-1">
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? 'Updating…' : 'Update password'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/(dashboard)/staff/settings/page.tsx
+++ b/app/(dashboard)/staff/settings/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import * as React from 'react'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+
+function levenshtein(a: string, b: string) {
+  const m = a.length, n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+  const dp = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+    }
+  return dp[m][n]
+}
+function tooSimilar(currentRaw: string, nextRaw: string): boolean {
+  const c = currentRaw.trim().toLowerCase(), n = nextRaw.trim().toLowerCase()
+  if (!c || !n) return false
+  if (c === n) return true
+  if ((c.length >= 4 && n.includes(c)) || (n.length >= 4 && c.includes(n))) return true
+  const dist = levenshtein(c, n), maxLen = Math.max(c.length, n.length)
+  return 1 - dist / Math.max(1, maxLen) >= 0.8
+}
+function meetsComplexity(pwd: string): boolean {
+  const s = pwd
+  const hasUpper = /[A-Z]/.test(s)
+  const hasLower = /[a-z]/.test(s)
+  const hasDigit = /[0-9]/.test(s)
+  const hasSymbol = /[^A-Za-z0-9]/.test(s)
+  const kinds = [hasUpper, hasLower, hasDigit, hasSymbol].filter(Boolean).length
+  return s.length >= 8 && kinds >= 3
+}
+function ClearButton({ onClick, label }: { onClick: () => void; label: string }) {
+  return (
+    <button type="button" aria-label={label} onClick={onClick} className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground hover:text-foreground" title="Clear">
+      ✕
+    </button>
+  )
+}
+
+export default function StaffSettingsPage() {
+  const [username, setUsername] = React.useState('staff')
+  const [email, setEmail] = React.useState('—')
+  React.useEffect(() => {
+    const u = typeof window !== 'undefined' ? localStorage.getItem('fd_username') : null
+    const e = typeof window !== 'undefined' ? localStorage.getItem('fd_email') : null
+    setUsername(u && u.trim() ? u : 'staff')
+    setEmail(e && e.trim() ? e : '—')
+  }, [])
+
+  const [currentPwd, setCurrentPwd] = React.useState('')
+  const [newPwd, setNewPwd] = React.useState('')
+  const [confirmPwd, setConfirmPwd] = React.useState('')
+  const [pwdSuccess, setPwdSuccess] = React.useState(false)
+
+  function onUpdatePassword() {
+    if (!currentPwd.trim() || !newPwd.trim() || !confirmPwd.trim()) return toast.error('All fields are required.')
+    if (newPwd !== confirmPwd) return toast.error("New password and confirmation don't match.")
+    if (tooSimilar(currentPwd, newPwd)) return toast.warning('New password is too similar to the current password.')
+    if (!meetsComplexity(newPwd)) return toast.warning('Use at least 8 characters and a mix of letters, numbers, and symbols.')
+    localStorage.setItem('fd_pwd_changed', '1')
+    localStorage.removeItem('fd_must_change_pwd')
+    setPwdSuccess(true)
+    setCurrentPwd(''); setNewPwd(''); setConfirmPwd('')
+  }
+
+  return (
+    <div className="space-y-6 mx-auto max-w-xl">
+      <div className="rounded-lg border bg-background p-4 shadow-sm">
+        <h3 className="text-sm font-medium mb-3">My Profile</h3>
+        <div className="grid gap-2 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Username</span>
+            <span className="font-medium">{username}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Email</span>
+            <span className="font-medium">{email}</span>
+          </div>
+        </div>
+      </div>
+      <div className="rounded-lg border bg-background p-4 shadow-sm">
+        <h3 className="text-sm font-medium mb-3">Change Password</h3>
+        <div className="grid gap-3 sm:max-w-lg">
+          <label className="grid gap-1 text-sm">
+            <span className="text-muted-foreground">Current password</span>
+            <div className="relative">
+              <input type="password" className="h-9 w-full rounded-md border px-3 pr-8 text-sm outline-none focus-visible:ring-2" value={currentPwd} onChange={(e) => setCurrentPwd(e.target.value)} placeholder="Enter current password" />
+              {currentPwd && <ClearButton onClick={() => setCurrentPwd('')} label="Clear current password" />}
+            </div>
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span className="text-muted-foreground">New password</span>
+            <div className="relative">
+              <input type="password" className="h-9 w-full rounded-md border px-3 pr-8 text-sm outline-none focus-visible:ring-2" value={newPwd} onChange={(e) => setNewPwd(e.target.value)} placeholder="Enter new password" />
+              {newPwd && <ClearButton onClick={() => setNewPwd('')} label="Clear new password" />}
+            </div>
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span className="text-muted-foreground">Confirm new password</span>
+            <div className="relative">
+              <input type="password" className="h-9 w-full rounded-md border px-3 pr-8 text-sm outline-none focus-visible:ring-2" value={confirmPwd} onChange={(e) => setConfirmPwd(e.target.value)} placeholder="Re-enter new password" />
+              {confirmPwd && <ClearButton onClick={() => setConfirmPwd('')} label="Clear confirmation password" />}
+            </div>
+          </label>
+          <div className="pt-1">
+            <Button size="sm" onClick={onUpdatePassword}>Update password</Button>
+          </div>
+        </div>
+        {/* Success modal */}
+        {pwdSuccess && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true">
+            <div className="w-full max-w-md rounded-lg border bg-background shadow-lg">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <h2 className="text-sm font-medium">Password Updated</h2>
+                <button className="rounded p-1 hover:bg-muted" onClick={() => setPwdSuccess(false)} aria-label="Close">✕</button>
+              </div>
+              <div className="p-4 space-y-3 text-sm">
+                <div>Your password has been updated successfully.</div>
+                <div className="pt-1">
+                  <Button size="sm" className="w-full" onClick={() => setPwdSuccess(false)}>Close</Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What
- Unified `/login` with role-aware redirect (Admin → `/admin/dashboard`, Staff → `/staff`)
- Staff first‑login enforcement in layout
- “Change Password” form with validation (current temp password check; strong rules; confirm match)
- On success: mark changed, clear flags, redirect to `/staff`
- Legacy `/staff/first-login` redirects to `/staff/settings`

## Files
- app/(auth)/login/page.tsx
- app/(dashboard)/staff/layout.tsx
- app/(dashboard)/staff/settings/components/password-change-form.tsx
- app/(dashboard)/staff/settings/page.tsx
- app/(auth)/staff/first-login/page.tsx
