### PR TITLE
 UI: Admin collapsible sidebar, header, and /admin redirect

### DIFF
--- a/app/(dashboard)/admin/components/admin-sidebar.tsx
+++ b/app/(dashboard)/admin/components/admin-sidebar.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import * as React from 'react'
+import { AppSidebar } from '../dashboard/components/app-sidebar'
+
+export function AdminSidebar({ collapsed = false }: { collapsed?: boolean }) {
+  return <AppSidebar collapsed={collapsed} />
+}

--- a/app/(dashboard)/admin/components/site-header.tsx
+++ b/app/(dashboard)/admin/components/site-header.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarRightExpand } from '@tabler/icons-react'
+
+function getTitle(pathname: string): string {
+  const path = pathname.replace(/\/+$/, '') || '/admin/dashboard'
+  if (path === '/admin' || path === '/admin/dashboard') return 'Admin Dashboard'
+  if (path.startsWith('/admin/staff')) return 'Staff'
+  if (path.startsWith('/admin/drivers')) return 'Drivers'
+  if (path.startsWith('/admin/restaurants')) return 'Restaurants'
+  if (path.startsWith('/admin/settings')) return 'Settings'
+  return 'Admin'
+}
+
+export function AdminSiteHeader({
+  collapsed,
+  onToggleSidebar,
+}: {
+  collapsed: boolean
+  onToggleSidebar: () => void
+}) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const title = getTitle(pathname)
+  const [username, setUsername] = React.useState('admin')
+
+  React.useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('fd_username') : null
+    setUsername(stored && stored.trim() ? stored : 'admin')
+  }, [])
+
+  async function handleLogout() {
+    try {
+      localStorage.removeItem('fd_auth')
+      localStorage.removeItem('fd_user')
+      sessionStorage.clear()
+      await fetch('/api/logout', { method: 'POST' }).catch(() => {})
+    } finally {
+      router.replace('/login')
+    }
+  }
+
+  return (
+    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-3 md:px-6">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            onClick={onToggleSidebar}
+          >
+            {collapsed ? (
+              <IconLayoutSidebarRightExpand className="h-5 w-5" />
+            ) : (
+              <IconLayoutSidebarLeftCollapse className="h-5 w-5" />
+            )}
+          </Button>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">Logged in: {username}</span>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button size="sm" variant="outline">Logout</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Log out?</AlertDialogTitle>
+                <AlertDialogDescription>You will be signed out of your admin session.</AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction asChild>
+                  <Button type="button" size="sm" variant="destructive" onClick={handleLogout}>
+                    Logout
+                  </Button>
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/app/(dashboard)/admin/dashboard/components/app-sidebar.tsx
+++ b/app/(dashboard)/admin/dashboard/components/app-sidebar.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+/**
+ * Admin Sidebar (icons-only when collapsed; full labels when expanded)
+ * - Collapsed: fixed rail (w-16). Icons larger (h-6 w-6) with tooltips via title/aria-label.
+ * - Expanded: full width (w-64). Brand + labels visible; icons default size.
+ * - Sidebar logout remains hidden on /admin/dashboard, shown elsewhere.
+ */
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  IconLayoutDashboard,
+  IconBuildingStore,
+  IconUsersGroup,
+  IconTruckDelivery,
+  IconSettings,
+} from '@tabler/icons-react'
+import * as React from 'react'
+import { LogoutButton } from '@/components/logout-button'
+
+type SidebarProps = {
+  name?: string
+  email?: string
+  variant?: string
+  collapsed?: boolean
+}
+
+export function AppSidebar({
+  name = 'Admin User',
+  email = 'admin@example.com',
+  variant: _variant,
+  collapsed = false,
+}: SidebarProps) {
+  const pathname = usePathname()
+
+  const items = React.useMemo(
+    () => [
+      { href: '/admin/dashboard', label: 'Dashboard', icon: IconLayoutDashboard },
+      { href: '/admin/restaurants', label: 'Restaurants', icon: IconBuildingStore },
+      { href: '/admin/staff', label: 'Staff', icon: IconUsersGroup },
+      { href: '/admin/drivers', label: 'Drivers', icon: IconTruckDelivery },
+      { href: '/admin/settings', label: 'Settings', icon: IconSettings },
+    ],
+    []
+  )
+
+  const isOnDashboard = pathname === '/admin/dashboard'
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Brand */}
+      <div className="border-b px-4 py-4">
+        <Link
+          href="/admin/dashboard"
+          className={`flex items-center gap-2 ${collapsed ? 'justify-center' : 'justify-start'}`}
+          title={collapsed ? 'FrontDash' : undefined}
+          aria-label="FrontDash"
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 font-bold text-primary">
+            FD
+          </div>
+          {!collapsed && <div className="text-lg font-semibold">FrontDash</div>}
+        </Link>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 p-2">
+        <ul className="space-y-1">
+          {items.map(({ href, label, icon: Icon }) => {
+            const active =
+              pathname === href ||
+              (href !== '/admin/dashboard' && pathname.startsWith(href))
+
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  data-active={active ? 'true' : 'false'}
+                  className={`flex items-center ${collapsed ? 'justify-center' : 'justify-start'} gap-3 rounded-md px-3 py-2 text-sm text-foreground/80 transition-colors hover:bg-muted hover:text-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground`}
+                  title={collapsed ? label : undefined}
+                  aria-label={collapsed ? label : undefined}
+                >
+                  <Icon className={collapsed ? 'h-6 w-6' : 'h-5 w-5'} />
+                  {!collapsed && <span>{label}</span>}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+
+      {/* User info + conditional Logout */}
+      <div className="mt-auto space-y-2 border-t px-4 py-3 text-sm">
+        {!collapsed && (
+          <div>
+            <div className="font-medium">{name}</div>
+            <div className="text-muted-foreground">{email}</div>
+          </div>
+        )}
+        {!isOnDashboard && <LogoutButton redirectTo="/login" className="w-full" />}
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/admin/layout.tsx
+++ b/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { SidebarProvider, Sidebar, SidebarInset } from '@/components/ui/sidebar'
+import { AdminStoreProvider } from './_state/admin-store'
+import { AdminSidebar } from './components/admin-sidebar'
+import { AdminSiteHeader } from './components/site-header'
+import { Toaster } from 'sonner'
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    const v = typeof window !== 'undefined' ? localStorage.getItem('fd_sidebar_collapsed') : null
+    setCollapsed(v === '1')
+  }, [])
+
+  function toggleSidebar() {
+    setCollapsed((c) => {
+      const next = !c
+      if (typeof window !== 'undefined') localStorage.setItem('fd_sidebar_collapsed', next ? '1' : '0')
+      return next
+    })
+  }
+
+  return (
+    <SidebarProvider>
+      <AdminStoreProvider>
+        <Sidebar
+          variant="inset"
+          className={
+            (collapsed ? 'w-16 min-w-[4rem]' : 'w-64 min-w-[16rem]') +
+            ' overflow-hidden transition-[width] duration-200'
+          }
+        >
+          <AdminSidebar collapsed={collapsed} />
+        </Sidebar>
+        <SidebarInset>
+          <AdminSiteHeader collapsed={collapsed} onToggleSidebar={toggleSidebar} />
+          <main className="flex-1 p-4 md:p-6">
+            <div className="mx-auto w-full max-w-6xl">{children}</div>
+          </main>
+          <Toaster richColors position="top-right" />
+        </SidebarInset>
+      </AdminStoreProvider>
+    </SidebarProvider>
+  )
+}


### PR DESCRIPTION
## What
- Admin & Staff collapsible sidebars (collapsed = icons only; expanded = icons + labels; “FrontDash” brand)
- Headers updated with collapse toggle
- Redirect `/admin` → `/admin/dashboard`
- Clean up duplicate/nested admin layout pieces

## Files
- app/(dashboard)/admin/layout.tsx
- app/(dashboard)/admin/components/admin-sidebar.tsx
- app/(dashboard)/admin/dashboard/components/app-sidebar.tsx
- app/(dashboard)/admin/components/site-header.tsx
- app/(dashboard)/staff/components/staff-sidebar.tsx
- app/(dashboard)/admin/page.tsx